### PR TITLE
Installation and setup tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 ## Prerequisites
 
 ```r
+install.packages('flexdashboard')
+devtools::install_github(c("rstudio/DT@joe/feature/crosstalk"))
 devtools::install_github(c(
   "jcheng5/d3scatter",
-  "rstudio/leaflet@joe/feature/crosstalk-filter",
-  "rstudio/DT@joe/feature/crosstalk"
+  "rstudio/leaflet@joe/feature/crosstalk-filter"
 ))
 ```

--- a/demo3.Rmd
+++ b/demo3.Rmd
@@ -11,6 +11,7 @@ runtime: shiny
 library(flexdashboard)
 library(crosstalk)
 library(dplyr)
+library(shiny)
 
 quakes$class <- factor(floor(quakes$mag), labels = c("Light", "Moderate", "Strong"))
 


### PR DESCRIPTION
Just a couple small tweaks which help me to get things running:
1. crosstalk failed to install when it was included in the batch list of dependencies, but worked fine when I installed it beforehand (If devtools goes in order of the entries, then simply shifting it may also work).
2. `renderPlot` isn't found without explicitly loading Shiny.

Very cool demos! Excited to put some of this functionality to use.
